### PR TITLE
klassy: fix build for Plasma 6 release

### DIFF
--- a/klassy/klassy.spec
+++ b/klassy/klassy.spec
@@ -8,25 +8,35 @@ URL: https://github.com/paulmcauley/klassy
 Source0: %{url}/archive/%{version}.tar.gz
 
 BuildRequires: cmake
-BuildRequires: cmake(KDecoration2)
-BuildRequires: cmake(KF5ConfigWidgets)
+BuildRequires: extra-cmake-modules
+BuildRequires: gettext
+BuildRequires: cmake(KF5Config)
 BuildRequires: cmake(KF5CoreAddons)
 BuildRequires: cmake(KF5FrameworkIntegration)
 BuildRequires: cmake(KF5GuiAddons)
-BuildRequires: cmake(KF5I18n)
-BuildRequires: cmake(KF5IconThemes)
-BuildRequires: cmake(KF5KCMUtils)
 BuildRequires: cmake(KF5Kirigami2)
-BuildRequires: cmake(KF5Package)
 BuildRequires: cmake(KF5WindowSystem)
-BuildRequires: cmake(Qt5Core)
+BuildRequires: cmake(KF5I18n)
 BuildRequires: cmake(Qt5DBus)
-BuildRequires: cmake(Qt5Gui)
 BuildRequires: cmake(Qt5Quick)
-BuildRequires: cmake(Qt5Svg)
+BuildRequires: cmake(Qt5Widgets)
 BuildRequires: cmake(Qt5X11Extras)
-BuildRequires: cmake(Qt6Gui)
-BuildRequires: extra-cmake-modules
+BuildRequires: cmake(KDecoration2)
+BuildRequires: cmake(KF6ColorScheme)
+BuildRequires: cmake(KF6Config)
+BuildRequires: cmake(KF6CoreAddons)
+BuildRequires: cmake(KF6FrameworkIntegration)
+BuildRequires: cmake(KF6GuiAddons)
+BuildRequires: cmake(KF6I18n)
+BuildRequires: cmake(KF6KCMUtils)
+BuildRequires: cmake(KF6KirigamiPlatform)
+BuildRequires: cmake(KF6WindowSystem)
+BuildRequires: cmake(Qt6Core)
+BuildRequires: cmake(Qt6DBus)
+BuildRequires: cmake(Qt6Quick)
+BuildRequires: cmake(Qt6Svg)
+BuildRequires: cmake(Qt6Widgets)
+BuildRequires: cmake(Qt6Xml)
 
 %description
 Klassy is a highly customizable binary Window Decoration and Application Style
@@ -56,18 +66,26 @@ cd build
 %{_datadir}/icons/hicolor/scalable/apps/klassy-settings.svgz
 %{_datadir}/icons/klassy*
 %{_datadir}/kstyle/themes/klassy.themerc
+%{_datadir}/plasma/desktoptheme/klassy
 %{_datadir}/plasma/layout-templates/org.kde.klassy*
 %{_datadir}/plasma/look-and-feel/org.kde.klassy*
 %{_prefix}/%{_lib}/cmake/Klassy/KlassyConfig.cmake
 %{_prefix}/%{_lib}/cmake/Klassy/KlassyConfigVersion.cmake
 %{_prefix}/%{_lib}/libklassycommon5.so.%{version}
-%{_prefix}/%{_lib}/libklassycommon5.so.5
-%{_prefix}/%{_lib}/qt5/plugins/org.kde.kdecoration2/klassydecoration.so
-%{_prefix}/%{_lib}/qt5/plugins/plasma/kcms/klassy
-%{_prefix}/%{_lib}/qt5/plugins/plasma/kcms/systemsettings_qwidgets/klassystyleconfig.so
-%{_prefix}/%{_lib}/qt5/plugins/styles/klassy.so
+%{_prefix}/%{_lib}/libklassycommon5.so.6
+%{_prefix}/%{_lib}/libklassycommon6.so.%{version}
+%{_prefix}/%{_lib}/libklassycommon6.so.6
+%{_prefix}/%{_lib}/qt5/plugins/styles/klassy5.so
+%{_prefix}/%{_lib}/qt6/plugins/kstyle_config/klassystyleconfig.so
+%{_prefix}/%{_lib}/qt6/plugins/org.kde.kdecoration2/org.kde.klassy.so
+%{_prefix}/%{_lib}/qt6/plugins/org.kde.kdecoration2.kcm/kcm_klassydecoration.so
+%{_prefix}/%{_lib}/qt6/plugins/org.kde.kdecoration2.kcm/klassydecoration/presets/*.klpw
+%{_prefix}/%{_lib}/qt6/plugins/styles/klassy6.so
 
 %changelog
+* Wed Apr 24 2024 GarciaLnk <alberto@garcialnk.com> - 6.1.breeze6.0.3
+- Fix build and include all files from Plasma 6 release.
+
 * Tue Mar 12 2024 ErrorNoInternet <errornointernet@envs.net> - 5.0.breeze5.27.11-3
 - Fix build by requiring Qt5Svg.
 - Include all files from new release.


### PR DESCRIPTION
This enables the creation of a .rpm for the Plasma 6 release of Klassy, as a result it makes this package incompatible with any version below Fedora 40.